### PR TITLE
Add HTTP handler

### DIFF
--- a/bin/execute_all_test
+++ b/bin/execute_all_test
@@ -8,6 +8,7 @@ sys.path = [sys.path[0]] \
     + [os.path.join(os.path.dirname(__file__), "../lib")] \
     + sys.path[1:]
 import dataprocessor as dp
+import handler
 sys.path = [sys.path[0]] + sys.path[2:]
 
 
@@ -26,6 +27,8 @@ def main():
     doctest.testmod(dp.pipes.jsonio)
     doctest.testmod(dp.pipes.scan)
     doctest.testmod(dp.pipes.table)
+
+    doctest.testmod(handler)
     return
 
 

--- a/lib/handler.py
+++ b/lib/handler.py
@@ -26,6 +26,25 @@ class Response(object):
     You can use this class by making instance of this class
     before sending Response.
 
+    Examples
+    --------
+    * JSON
+    >>> res = Response("json")
+    >>> res.set_body("{'exit_code' : 0}")
+    >>> print(res) # doctest: +SKIP
+
+    * HTML
+    >>> res = Response("html")
+    >>> res.set_body('''
+    ...     <!DOCTYPE html>
+    ...     <html>
+    ...         <body>
+    ...             <h1>My Home Page!</h1>
+    ...         </body>
+    ...     </html>
+    ...     ''')
+    >>> print(res) # doctest: +SKIP
+
     """
 
     def __init__(self, content_type="html", charset='utf-8'):
@@ -51,7 +70,11 @@ class Response(object):
         return self.headers.get(name, None)
 
     def set_body(self, bodystr):
-        """Return the string of <body> tag."""
+        """Set the body of response.
+
+        See Examples of this class.
+
+        """
         self.body = bodystr
 
     def make_output(self, timestamp=None):


### PR DESCRIPTION
A general HTTP handler wrapper.
It is necessary to implement APIs argued in #31.

I split pull-request #34 because it becomes complicated.
