### PR TITLE
Change the behavior in editing comment.

### DIFF
--- a/server/js/table.js
+++ b/server/js/table.js
@@ -69,7 +69,7 @@ function ready_table(){
                     .attr("value", comment)
                     .attr("path", path)
                 );
-            $parent.find("input.comment").focus();
+            $parent.children("input.comment").focus();
         })
         .on("blur", "table>tbody>tr>input.comment", function(event){
             var comment = this.value;


### PR DESCRIPTION
I changed the behavior in editing comment.

Previously, when you click the comment, the unfocused form are opened.
This change enable to focus to the opened form in clicking the comment. 
