### PR TITLE
Environment values

### DIFF
--- a/lib/dataprocessor/io.py
+++ b/lib/dataprocessor/io.py
@@ -131,7 +131,9 @@ class DataHandler(object):
         nodes.add(self.node_list, node, skip_validate_link)
 
     def update(self, node_list, skip_validate_link=False):
-        """ Update node_list.
+        """ Update node_list (use dict.update).
+
+        See also the help of nodes.add.
 
         Parameters
         ----------

--- a/lib/dataprocessor/rc.py
+++ b/lib/dataprocessor/rc.py
@@ -17,7 +17,7 @@ def ArgumentParser(rcpath=default_rcpath):
 
     Parameter
     ---------
-    rcpath: str, optional
+    rcpath : str, optional
         path of configure file (default=~/.dataprocessor.ini)
 
     Return
@@ -40,7 +40,7 @@ def load(rcpath=default_rcpath):
 
     Parameter
     ---------
-    rcpath: str, optional
+    rcpath : str, optional
         path of configure file (default=~/.dataprocessor.ini)
 
     Return
@@ -57,7 +57,7 @@ def update(node_list, rcpath=default_rcpath):
 
     Parameter
     ---------
-    rcpath: str, optional
+    rcpath : str, optional
         path of configure file (default=~/.dataprocessor.ini)
 
     """
@@ -71,7 +71,7 @@ def create_configure_file(rcpath=default_rcpath):
 
     Parameter
     ---------
-    rcpath: str, optional
+    rcpath : str, optional
         path of configure file (default=~/.dataprocessor.ini)
 
     """
@@ -107,7 +107,7 @@ def load_configure_file(rcpath=default_rcpath):
 
     Parameter
     ---------
-    rcpath: str, optional
+    rcpath : str, optional
         path of configure file (default=~/.dataprocessor.ini)
 
     Return
@@ -115,8 +115,8 @@ def load_configure_file(rcpath=default_rcpath):
     dict
         There are two keys: "root" and "json".
 
-    Exception
-    ---------
+    Raise
+    -----
     DataProcessorError
         raised when configure file does not exist.
 


### PR DESCRIPTION
In order to manage environmental values, I introduce `dp.rc` module.
This will be helpful to implement executables such as `dpmanip`,
since this allows omitting path of `data.json` from command line arguments.
