### PR TITLE
Revise update strategy of dp.nodes.add

### DIFF
--- a/bin/dpmanip
+++ b/bin/dpmanip
@@ -26,9 +26,9 @@ def main(args):
         with dp.io.SyncDataHandler(args.json, silent=args.silent) as dh:
             node_list = args.val["func"](dh.get(), *arguments, **keywords)
             if args.replace:
-                dh.replace(node_list, silent=args.silent)
+                dh.replace(node_list)
             else:
-                dh.update(node_list, silent=args.silent)
+                dh.update(node_list)
         return
 
     if args.input:
@@ -42,9 +42,9 @@ def main(args):
     else:
         with dp.io.SyncDataHandler(args.json, silent=args.silent) as dh:
             if args.replace:
-                dh.replace(node_list, silent=args.silent)
+                dh.replace(node_list)
             else:
-                dh.update(node_list, silent=args.silent)
+                dh.update(node_list)
 
 
 if __name__ == '__main__':

--- a/lib/dataprocessor/io.py
+++ b/lib/dataprocessor/io.py
@@ -147,7 +147,7 @@ class DataHandler(object):
         for node in node_list:
             nodes.validate_link(node_list, node, silent=True)
 
-    def replace(self, node_list, skip_validate_link=True, silent=False):
+    def replace(self, node_list, skip_validate_link=True):
         """ Swap node_list.
 
         Parameters
@@ -159,7 +159,7 @@ class DataHandler(object):
         self.node_list = node_list
         if not skip_validate_link:
             for node in self.node_list:
-                nodes.validate_link(self.node_list, node, silent=silent)
+                nodes.validate_link(self.node_list, node, silent=True)
 
     def serialize(self):
         save(self.node_list, self.data_path, self.silent)

--- a/lib/dataprocessor/io.py
+++ b/lib/dataprocessor/io.py
@@ -131,7 +131,7 @@ class DataHandler(object):
         nodes.add(self.node_list, node, strategy, skip_validate_link)
 
     def update(self, node_list, skip_validate_link=False):
-        """ Update node_list (use nodes.update).
+        """ Update node_list (use nodes.modest_update).
 
         Parameters
         ----------
@@ -139,11 +139,9 @@ class DataHandler(object):
             skip link validation about all nodes in new `node_list`
         """
         for node in node_list:
-            try:
-                nodes.add(self.node_list, node, strategy="raise",
-                          skip_validate_link=skip_validate_link)
-            except nodes.DataProcessorNodesError:
-                nodes.update(self.node_list, node, skip_validate_link=False)
+            nodes.add(self.node_list, node,
+                      strategy="modest_update",
+                      skip_validate_link=skip_validate_link)
         if skip_validate_link:
             return
         for node in node_list:

--- a/lib/dataprocessor/io.py
+++ b/lib/dataprocessor/io.py
@@ -119,7 +119,7 @@ class DataHandler(object):
     def get(self):
         return self.node_list
 
-    def add(self, node, skip_validate_link=False):
+    def add(self, node, strategy="update", skip_validate_link=False):
         """ Add node into managed node_list.
 
         Parameters
@@ -128,24 +128,26 @@ class DataHandler(object):
             skip link check (default=False)
 
         """
-        nodes.add(self.node_list, node, skip_validate_link)
+        nodes.add(self.node_list, node, strategy, skip_validate_link)
 
-    def update(self, node_list, silent=False):
-        """ Update node_list (use dict.update).
-
-        See also the help of nodes.add.
+    def update(self, node_list, skip_validate_link=False):
+        """ Update node_list (use nodes.update).
 
         Parameters
         ----------
         skip_validate_link : bool, optional
             skip link validation about all nodes in new `node_list`
-
         """
         for node in node_list:
-            nodes.add(self.node_list, node, skip_validate_link=True,
-                      strategy="update")
+            try:
+                nodes.add(self.node_list, node, strategy="raise",
+                          skip_validate_link=skip_validate_link)
+            except nodes.DataProcessorNodesError:
+                nodes.update(self.node_list, node, skip_validate_link=False)
+        if skip_validate_link:
+            return
         for node in node_list:
-            nodes.validate_link(node_list, node, silent)
+            nodes.validate_link(node_list, node, silent=True)
 
     def replace(self, node_list, skip_validate_link=True, silent=False):
         """ Swap node_list.

--- a/lib/dataprocessor/nodes.py
+++ b/lib/dataprocessor/nodes.py
@@ -165,7 +165,7 @@ def add(node_list, node, skip_validate_link=False, strategy="raise"):
         The node will be added into node_list
     skip_validate_link : bool, optional
         skip link validation (default False)
-    strategy : str, optional {"raise", "update", "replace"}
+    strategy : str, optional {"raise", "update", "modest_update", "replace"}
         The strategy for the case
         where there exists a node whose "path" is same as new one
 

--- a/lib/dataprocessor/nodes.py
+++ b/lib/dataprocessor/nodes.py
@@ -150,7 +150,7 @@ def update(node_list, node, skip_validate_link=False):
         validate_link(node_list, node0)
 
 
-def add(node_list, node, skip_validate_link=False, strategy="update"):
+def add(node_list, node, skip_validate_link=False, strategy="raise"):
     """Add a node into node_list.
 
     This adds a node into node_list,
@@ -165,12 +165,20 @@ def add(node_list, node, skip_validate_link=False, strategy="update"):
         The node will be added into node_list
     skip_validate_link : bool, optional
         skip link validation (default False)
-    strategy : str, optional {"update", "replace"}
+    strategy : str, optional {"raise", "update", "replace"}
         The strategy for the case
         where there exists a node whose "path" is same as new one
 
+        - "raise" : raise DataProcessorNodesError (default)
         - "update" : use dict.update to update existing node
         - "replace" : replace existing node with new node
+
+    Raises
+    ------
+    DataProcessorNodesError:
+        there is already exist node whose path is `node["path"]`
+    DataProcessorError:
+        strategy is invalid string
 
     Examples
     --------
@@ -184,7 +192,9 @@ def add(node_list, node, skip_validate_link=False, strategy="update"):
     """
     node0 = get(node_list, node["path"])
     if node0:
-        if strategy is "update":
+        if strategy is "raise":
+            raise DataProcessorNodesError("node already exists")
+        elif strategy is "update":
             node0.update(node)
             node = node0
         elif strategy is "replace":

--- a/lib/dataprocessor/nodes.py
+++ b/lib/dataprocessor/nodes.py
@@ -147,7 +147,7 @@ def modest_update(node_list, node, skip_validate_link=False):
         if val:
             node0[key] = val
     if not skip_validate_link:
-        validate_link(node_list, node0)
+        validate_link(node_list, node0, silent=True)
 
 
 def add(node_list, node, skip_validate_link=False, strategy="raise"):
@@ -210,7 +210,7 @@ def add(node_list, node, skip_validate_link=False, strategy="raise"):
         else:
             raise DataProcessorError("Invalid strategy: %s" % strategy)
     if not skip_validate_link:
-        validate_link(node_list, node)
+        validate_link(node_list, node, silent=True)
 
 
 def check_duplicate(node_list):

--- a/lib/dataprocessor/nodes.py
+++ b/lib/dataprocessor/nodes.py
@@ -6,6 +6,14 @@ from . import utility
 node_types = ["run", "project", "figure"]
 
 
+class DataProcessorNodesError(DataProcessorError):
+
+    """Exception about Nodes processings."""
+
+    def __init__(self, msg):
+        DataProcessorError.__init__(self, msg)
+
+
 def normalize(node):
     """ Normalize node (i.e. fill necessary field).
 
@@ -82,6 +90,64 @@ def get(node_list, path):
         if path == node["path"]:
             return node
     return None
+
+
+def update(node_list, node, skip_validate_link=False):
+    """ Update node properties
+
+    This keeps values as possible,
+    besides the "update" strategy of `add(...)` simply uses `dict.update()`.
+    If `node` in the arguments has empty value
+    e.g. `node = {"path": "/path/0", "comment" : ""}`,
+    this function does not overwrite existing comment of
+    the node in `node_list`.
+
+    Parameters
+    ----------
+    node_list : list
+        the list of nodes
+    node : dict
+        The node will be added into node_list
+    skip_validate_link : bool, optional
+        skip link validation (default False)
+
+    Raises
+    ------
+    DataProcessorNodesError
+        there is no node whose "path" is `node["path"]`
+
+    Examples
+    --------
+    >>> node_list = [{
+    ...   "path": "/path/0",
+    ...   "comment": "some comment",
+    ...   "children": [],
+    ...   "parents": [],
+    ... }]
+    >>> node = {
+    ...   "path":"/path/0",
+    ...   "configure": {"A": 1.0},
+    ...   "comment": "",
+    ... }
+    >>> update(node_list, node)
+    >>> node_list == [{
+    ...   'comment': 'some comment',
+    ...   'path': '/path/0',
+    ...   'parents': [],
+    ...   'children': [],
+    ...   'configure': {'A': 1.0}
+    ... }]
+    True
+    """
+    node0 = get(node_list, node["path"])
+    if not node0:
+        raise DataProcessorNodesError("There is no node [path={}]".format(
+                                      node["path"]))
+    for key, val in node.items():
+        if val:
+            node0[key] = val
+    if validate_link:
+        validate_link(node_list, node0)
 
 
 def add(node_list, node, skip_validate_link=False, strategy="update"):

--- a/lib/dataprocessor/pipes/add_node.py
+++ b/lib/dataprocessor/pipes/add_node.py
@@ -39,7 +39,10 @@ def add_node(node_list, path=".", node_type="run", children=[],
             "children": [utility.path_expand(c_path) for c_path in children],
             "parents": [utility.path_expand(c_path) for c_path in parents],
             "name": name}
-    nodes.add(node_list, node)
+    try:
+        nodes.add(node_list, node)
+    except nodes.DataProcessorNodesError:
+        nodes.update(node_list, node)
     return node_list
 
 

--- a/lib/dataprocessor/pipes/add_node.py
+++ b/lib/dataprocessor/pipes/add_node.py
@@ -39,10 +39,7 @@ def add_node(node_list, path=".", node_type="run", children=[],
             "children": [utility.path_expand(c_path) for c_path in children],
             "parents": [utility.path_expand(c_path) for c_path in parents],
             "name": name}
-    try:
-        nodes.add(node_list, node)
-    except nodes.DataProcessorNodesError:
-        nodes.update(node_list, node)
+    nodes.add(node_list, node, strategy="modest_update")
     return node_list
 
 

--- a/lib/dataprocessor/pipes/add_node.py
+++ b/lib/dataprocessor/pipes/add_node.py
@@ -6,10 +6,10 @@ from .. import utility
 
 
 def add_node(node_list, path=".", node_type="run", children=[],
-             name=None, parents=[".."]):
+             name=None, parents=[".."], strategy="raise"):
     """Add node.
 
-    A node is added to the node_list according to dict.update.
+    A node is added to the node_list.
 
     Parameters
     ----------
@@ -20,6 +20,11 @@ def add_node(node_list, path=".", node_type="run", children=[],
     name : str, optional
     children : list, optional
     parents : list, optional
+    strategy : str, optional
+        determines how to deal with conflict,
+        i.e. there alread exists another node
+        whose path is same as new one.
+        See docstring of nodes.add.
 
     Returns
     -------
@@ -35,11 +40,14 @@ def add_node(node_list, path=".", node_type="run", children=[],
     if not name:
         name = os.path.basename(path)
 
-    node = {"path": path, "type": node_type,
-            "children": [utility.path_expand(c_path) for c_path in children],
-            "parents": [utility.path_expand(c_path) for c_path in parents],
-            "name": name}
-    nodes.add(node_list, node, strategy="modest_update")
+    node = nodes.normalize({
+        "path": path,
+        "type": node_type,
+        "children": [utility.path_expand(c_path) for c_path in children],
+        "parents": [utility.path_expand(c_path) for c_path in parents],
+        "name": name
+    })
+    nodes.add(node_list, node, strategy=strategy)
     return node_list
 
 
@@ -47,6 +55,19 @@ def register(pipes_dics):
     pipes_dics["add_node"] = {
         "func": add_node,
         "args": [],
-        "kwds": ["path", "node_type", "children", "name", "parents"],
+        "kwds": [
+            ("path", {"help": "path of new node"}),
+            ("name", {"help": "name of new node"}),
+            ("node_type", {
+                "help": "type of new node",
+                "choices": nodes.node_types,
+            }),
+            ("children", {"help": "children paths of new node"}),
+            ("parents", {"help": "paths parents of new node"}),
+            ("strategy", {
+                "help": "strategy for resolving conflict",
+                "choices": ["raise", "update", "modest_update", "replace"],
+            }),
+        ],
         "desc": "Add node to node_list."
     }

--- a/lib/dataprocessor/pipes/merge_nodelist.py
+++ b/lib/dataprocessor/pipes/merge_nodelist.py
@@ -1,0 +1,37 @@
+# coding=utf-8
+
+import json
+
+from .. import nodes
+from .. import utility
+
+
+def merge_nodelist(node_list, json_filename):
+    """ Merge another node_list.
+
+    Parameters
+    ----------
+    json_fn : str
+        filename of JSON file including another node_list
+    """
+    fn = utility.check_file(json_filename)
+    with open(fn) as f:
+        another_nl = json.load(f)
+    for node in another_nl:
+        nodes.add(node_list, node,
+                  strategy="modest_update",
+                  skip_validate_link=True)
+    for node in node_list:
+        nodes.validate_link(node_list, node, silent=True)
+    return node_list
+
+
+def register(pipes_dics):
+    pipes_dics["merge_nodelist"] = {
+        "func": merge_nodelist,
+        "args": [("json_filename", {
+            "help": "path of another JSON file"
+        })],
+        "kwds": [],
+        "desc": "Merge another node_list",
+    }

--- a/lib/dataprocessor/pipes/merge_nodelist.py
+++ b/lib/dataprocessor/pipes/merge_nodelist.py
@@ -13,6 +13,53 @@ def merge_nodelist(node_list, json_filename):
     ----------
     json_fn : str
         filename of JSON file including another node_list
+
+    Example
+    -------
+    >>> from tempfile import NamedTemporaryFile
+    >>> nl1 = [{
+    ...     u"path": u"/path/1",
+    ...     u"type": u"run",
+    ...     u"children": [u"/path/2"],
+    ...     u"parents": [],
+    ... }, {
+    ...     u"path": u"/path/2",
+    ...     u"type": u"run",
+    ...     u"children": [],
+    ...     u"parents": [u"/path/1"],
+    ... }]
+    >>> with NamedTemporaryFile(suffix=".json", delete=False) as f:
+    ...     json.dump(nl1, f)
+    >>> nl2 = [{
+    ...     u"path": u"/path/1",
+    ...     u"type": u"run",
+    ...     u"children": [u"/path/3"],
+    ...     u"parents": [],
+    ... }, {
+    ...     u"path": u"/path/3",
+    ...     u"type": u"run",
+    ...     u"children": [],
+    ...     u"parents": [u"/path/1"],
+    ... }]
+    >>> nl = merge_nodelist(nl2, f.name)
+    >>> nl == [{
+    ...     u"path": u"/path/1",
+    ...     u"type": u"run",
+    ...     u"children": [u"/path/2", u"/path/3"],
+    ...     u"parents": [],
+    ... }, {
+    ...     u"path": u"/path/3",
+    ...     u"type": u"run",
+    ...     u"children": [],
+    ...     u"parents": [u"/path/1"],
+    ... }, {
+    ...     u"path": u"/path/2",
+    ...     u"type": u"run",
+    ...     u"children": [],
+    ...     u"parents": [u"/path/1"],
+    ... }]
+    True
+
     """
     fn = utility.check_file(json_filename)
     with open(fn) as f:

--- a/lib/dataprocessor/tests/test_add_node.py
+++ b/lib/dataprocessor/tests/test_add_node.py
@@ -14,7 +14,8 @@ class TestAddNode(TestNodeListAndDir):
         compare_list = self._create_compare_node_list()
 
         runpath = os.path.join(self.project_paths[0], "run02")
-        add_node(self.node_list, path=runpath, parents=self.project_paths[0])
+        add_node(self.node_list, path=runpath, parents=self.project_paths[0],
+                 strategy="modest_update")
         self.assertEqual(self.node_list, compare_list)
 
     def _create_compare_node_list(self):

--- a/lib/dataprocessor/tests/test_add_node.py
+++ b/lib/dataprocessor/tests/test_add_node.py
@@ -21,10 +21,10 @@ class TestAddNode(TestNodeListAndDir):
         compare_list = copy.deepcopy(self.node_list)
         for n in self.node_list:
             nodes.validate_link(self.node_list, n)
-        node = {"path": os.path.join(self.project_paths[0], "run02"),
-                "parents": [self.project_paths[0]]}
-        try:
-            nodes.add(compare_list, node)
-        except nodes.DataProcessorNodesError:
-            nodes.update(compare_list, node)
+        node = {
+            "path": os.path.join(self.project_paths[0], "run02"),
+            "parents": [self.project_paths[0]],
+            "children": []
+        }
+        nodes.add(compare_list, node, strategy="modest_update")
         return compare_list

--- a/lib/dataprocessor/tests/test_add_node.py
+++ b/lib/dataprocessor/tests/test_add_node.py
@@ -23,5 +23,8 @@ class TestAddNode(TestNodeListAndDir):
             nodes.validate_link(self.node_list, n)
         node = {"path": os.path.join(self.project_paths[0], "run02"),
                 "parents": [self.project_paths[0]]}
-        nodes.add(compare_list, node)
+        try:
+            nodes.add(compare_list, node)
+        except nodes.DataProcessorNodesError:
+            nodes.update(compare_list, node)
         return compare_list

--- a/lib/dataprocessor/tests/test_nodes.py
+++ b/lib/dataprocessor/tests/test_nodes.py
@@ -85,7 +85,7 @@ class TestNodes(unittest.TestCase):
             "parents": ["/path/2"],
             "children": ["/path/1", "/path/3"]
         }
-        nodes.add(node_list, new_node, skip_validate_link=True)
+        nodes.add(node_list, new_node, strategy="update", skip_validate_link=True)
 
         compare_node_list = [
             {"path": "/path/0", "parents": ["/path/2"],
@@ -105,7 +105,7 @@ class TestNodes(unittest.TestCase):
             "parents": ["/path/0"],
             "children": []
         }
-        nodes.add(node_list, new_node)
+        nodes.add(node_list, new_node, strategy="update")
 
         compare_node_list = [
             {"path": "/path/0", "parents": ["/path/1"],


### PR DESCRIPTION
Objective
------------

- Do not update if overwritting value is empty.

Detail
--------
Please consider the following case:
```
node_list = [{
  "path": "/path/0",
  "comment": "some comment"
}]
node = {
  "path":"/path/0",
  "comment": ""
}
nodes.add(node_list, node)
print(node_list)
```

I think comment "some comment" should not be overwrite with "" in this case.
However, this patch causes another problem for "children" and "parents" property,
i.e. `[]` is meaningful in this case (see changes in test code).

What do you think about it?

TODO
--------
- [x] merge_nodelistのテスト