### PR TITLE
Add project pipe

### DIFF
--- a/lib/dataprocessor/filter.py
+++ b/lib/dataprocessor/filter.py
@@ -24,9 +24,9 @@ def project(node_list, path):
 
     """
     if isinstance(path, str):
-        paths = [rc.get_project_dir(path)]
+        paths = [rc.resolve_project_path(path)]
     elif isinstance(path, list):
-        paths = [rc.get_project_dir(p) for p in path]
+        paths = [rc.resolve_project_path(p) for p in path]
     else:
         raise DataProcessorError("Arguemnt path must be str or [str]")
     return [node for node in node_list

--- a/lib/dataprocessor/pipes/add_tag.py
+++ b/lib/dataprocessor/pipes/add_tag.py
@@ -1,26 +1,28 @@
 # coding=utf-8
 from ..nodes import get, add
 from ..utility import path_expand
-from ..rc import get_project_dir
+from ..rc import resolve_project_path
 from ..exception import DataProcessorError
 
 import os.path
 
 
-def add_project(node_list, node_path, project_name):
-    """
-    Add comment to node spedcified path.
+def add_tag(node_list, node_path, project_id):
+    """ Make the node belong to the project specified by project id.
+
+    We realize "tagging" feature by project nodes.
 
     Parameters
     ----------
-    project_name : str
-        comment.
     node_path : str
         This path specify the unique node.
+    project_id: str
+        the name or path of project.
+        The path is resolved by resolve_project_path.
 
     """
     path = path_expand(node_path)
-    project_path = get_project_dir(project_name)
+    project_path = resolve_project_path(project_id)
     project_node = get(node_list, project_path)
     if not project_node:
         add(node_list, {
@@ -42,8 +44,8 @@ def add_project(node_list, node_path, project_name):
 
 
 def register(pipe_dics):
-    pipe_dics["add_project"] = {
-        "func": add_project,
-        "args": ["path", "project_name"],
-        "desc": "add project",
+    pipe_dics["add_tag"] = {
+        "func": add_tag,
+        "args": ["path", "project_id"],
+        "desc": "Add a tag into the node",
     }

--- a/lib/dataprocessor/rc.py
+++ b/lib/dataprocessor/rc.py
@@ -229,7 +229,7 @@ def get_configure_safe(section, key, default, rcpath=default_rcpath):
         return default
 
 
-def _get_dir(name, root, basket_name, rcpath):
+def _resolve_path(name, root, basket_name, rcpath):
     if not root:
         root = get_configure(rc_section, "root", rcpath=rcpath)
     root = utility.check_directory(root)
@@ -237,22 +237,34 @@ def _get_dir(name, root, basket_name, rcpath):
     return utility.get_directory(os.path.join(basket, name))
 
 
-def get_project_dir(name, root=None, basket_name="Projects",
-                    rcpath=default_rcpath):
-    """ Generate project directory, if it exists, returns its abspath.
+def resolve_project_path(name_or_path, root=None,
+                         basket_name=get_configure_safe(rc_section,
+                                                        "project_basket",
+                                                        "Projects"),
+                         rcpath=default_rcpath):
+    """ Resolve project path from its path or name.
 
     Parameters
     ----------
-    name : str
-        project name (not path)
+    name_or_path : str
+        Project identifier.
+        If name (i.e. basename(name_or_path) == name_or_path),
+        abspath of `root/basket_name/name` is returned.
+        If path (otherwise case), returns its abspath.
     root : str, optional
-        new run directory is made in `${root}/${basket_name}/`.
-        If not specified, "root" value of the setting file is used.
+        The root path of baskets. (default=None)
+        If None, the path is read from the configure file.
     basket_name : str, optional
-        new run directory is made in `${root}/${basket_name}/`.
-        (default="Projects")
+        The name of the project basket.
+        If "project_basket" is specified in the configure file,
+        default value is it. Otherwise, default is "Projects".
     rcpath : str, optional
         path of the setting file
+
+    Returns
+    -------
+    path : str
+        existing project path
 
     Raises
     ------
@@ -261,7 +273,7 @@ def get_project_dir(name, root=None, basket_name="Projects",
         from the setting file.
 
     """
-    if os.path.basename(name) == name:
-        return _get_dir(name, root, basket_name, rcpath)
+    if os.path.basename(name_or_path) == name_or_path:
+        return _resolve_path(name_or_path, root, basket_name, rcpath)
     else:
-        return utility.get_directory(name)
+        return utility.get_directory(name_or_path)


### PR DESCRIPTION
## Objective

I hope the following command works.

``` command
dpmanip -s add_project . project1
```

It is important to specify a project by its name not by path.
## Summary
- introduce `rc.get_project_dir` to generate path from name
- introduce `add_project` pipe

The directory in which the project directory will be created is specified by the setting file (`~/.dataprocessor.ini`),
and thus `get_project_dir` is included in `rc`.
