### PR TITLE
Bug fixed.

### DIFF
--- a/lib/dataprocessor/dataframe.py
+++ b/lib/dataprocessor/dataframe.py
@@ -54,10 +54,17 @@ def get_project(node_list, project_path, properties=["comment", "tags"],
             properties.append(item)
 
     def _conv(val):
-        sr = Series(val["configure"])
+        new = {}
+        for key, value in val["configure"].items():
+            try:
+                new[key] = float(value)
+            except:
+                new[key] = value
+        sr = Series(new)
         for prop in properties:
             sr.set_value(prop, val[prop])
         return sr
+
     runs = runs_pre.apply(_conv, axis=1)
     runs = runs.convert_objects(convert_numeric=True)
     if index:


### PR DESCRIPTION
# Objective

The bug related to #160 is fixed.
# Problem

Although `convert_object` convert `1.0e-12` to `1.0000e-12`, it convert `1e-12` to `0` when all column values is match with the regular expression "[1-9]+e-[1-9]+".
# Changes

Before applying `convert_object`, all values are tried to convert to float type.
