### PR TITLE
Support OSX in start_ipynb

### DIFF
--- a/lib/dataprocessor/pipes/ipynb.py
+++ b/lib/dataprocessor/pipes/ipynb.py
@@ -12,7 +12,7 @@ def gather_notebooks():
     """
     notes = []
     for p in psutil.process_iter():
-        if not p.name().startswith("ipython"):
+        if not p.name().lower() in ["ipython", "python"]:
             continue
         if "notebook" not in p.cmdline():
             continue
@@ -55,7 +55,7 @@ def start(nl, ipynb_path):
         cwd = note["cwd"]
         if not ipynb_path.startswith(cwd):
             continue
-        note["postfix"] = ipynb_path[len(cwd)+1:]  # remove '/'
+        note["postfix"] = ipynb_path[len(cwd) + 1:]  # remove '/'
         url = "http://localhost:{port}/notebooks/{postfix}".format(**note)
         try:
             webbrowser.open(url)


### PR DESCRIPTION
Related to #170.

On OSX,  `p.name()` of process belonging to python returns "Python". Because of this, gather_notebooks does not work well.
