### PR TITLE
Fix build on travis-ci

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jinja2>=1.7
-python-daemon>=0.6
+python-daemon==1.6.1
 Sphinx>=1.2
 numpydoc>=0.4
 pandas>=0.14


### PR DESCRIPTION
Due to bugs related to https://lists.alioth.debian.org/pipermail/python-daemon-devel/2015-January/000111.html, the build of this package on travis-ci is failed. Then, previous python-daemon version is specified.

If this PR is merged. All PR should be merged or rebased.