### PR TITLE
Enter and Shift+Enter for dpcomment textareas

### DIFF
--- a/server/static/js/comment.js
+++ b/server/static/js/comment.js
@@ -18,6 +18,20 @@ function send_comment(comment, path){
     });
 }
 
+function dpcomment_keydown_handler(e) {
+  if (e.keyCode == 13) {  // Enter is pressed
+    if (e.shiftKey) {
+      // do nothing
+    } else if (e.ctrlKey) {
+      // do nothing
+    } else if (e.altKey) {
+      // do nothing
+    } else {  // Enter only
+      $(this).blur();
+    }
+  }
+}
+
 function enable_editable_comment() {
   f_click = function(){
     var comment = $(this).text();
@@ -26,6 +40,7 @@ function enable_editable_comment() {
     $("<textarea>")
       .val(comment)
       .attr("dp-path", path)
+      .keydown(dpcomment_keydown_handler)
       .addClass("form-control")
       .appendTo(this)
       .focus();


### PR DESCRIPTION
- Enter: 確定（テキストエリアのフォーカスを外す）
- Shift+Enter: 改行

将来Alt+Enter, Ctrl+Enterを使うかもしれないので一応残しておいた。