### PR TITLE
dpstart

### DIFF
--- a/bin/dpstart
+++ b/bin/dpstart
@@ -15,29 +15,19 @@ sys.path = ([sys.path[0]]
 import dataprocessor as dp
 sys.path = [sys.path[0]] + sys.path[2:]
 
-def _add(l, name):
-    if name not in l:
-        l.append(name)
+
+def uniq(l):
+    return list(set(l))
 
 
 def main(args):
     name = args.name or dp.utility.now_str()
-
-    ps = args.projects
-    _add(ps, os.path.basename(args.args[0]))
-
-    req = args.requirements
-    for a in args.args:
-        p = os.path.abspath(a)
-        if os.path.exists(p):
-            logger.info("Add requirements: " + p)
-            _add(req, p)
-
+    ps = uniq(args.projects + [os.path.basename(args.args[0])])
+    req = uniq(args.requirements + filter(os.path.exists, map(os.path.abspath, args.args)))
     with dp.io.SyncDataHandler(args.json) as dh:
         nl = dh.get()
         node = dp.starter.start(nl, args.args, req, name=name, projects=ps, runner=args.runner)
         dh.update(nl)
-
     logger.info("Create new node: " + node["path"])
 
 

--- a/bin/dpstart
+++ b/bin/dpstart
@@ -7,22 +7,44 @@ import json
 import traceback
 import logging
 
+logger = logging.getLogger("dataprocessor")
+
 sys.path = ([sys.path[0]]
             + [os.path.join(os.path.dirname(__file__), "../lib")]
             + sys.path[1:])
 import dataprocessor as dp
 sys.path = [sys.path[0]] + sys.path[2:]
 
+def _add(l, name):
+    if name not in l:
+        l.append(name)
+
 
 def main(args):
-    pass
+    name = args.name or dp.utility.now_str()
+
+    ps = args.projects
+    _add(ps, os.path.basename(args.args[0]))
+
+    req = args.requirements
+    for a in args.args:
+        p = os.path.abspath(a)
+        if os.path.exists(p):
+            logger.info("Add requirements: " + p)
+            _add(req, p)
+
+    with dp.io.SyncDataHandler(args.json) as dh:
+        nl = dh.get()
+        node = dp.starter.start(nl, args.args, req, name=name, projects=ps, runner=args.runner)
+        dh.update(nl)
+
+    logger.info("Create new node: " + node["path"])
 
 
 if __name__ == '__main__':
     parser = dp.argparsers.dpstart()
     args = parser.parse_args()
 
-    logger = logging.getLogger("dataprocessor")
     logger.addHandler(logging.StreamHandler())
     if args.debug:
         logger.setLevel(logging.DEBUG)

--- a/bin/dpstart
+++ b/bin/dpstart
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os.path
+import sys
+import json
+import traceback
+import logging
+
+sys.path = ([sys.path[0]]
+            + [os.path.join(os.path.dirname(__file__), "../lib")]
+            + sys.path[1:])
+import dataprocessor as dp
+sys.path = [sys.path[0]] + sys.path[2:]
+
+
+def main(args):
+    pass
+
+
+if __name__ == '__main__':
+    parser = dp.argparsers.dpstart()
+    args = parser.parse_args()
+
+    logger = logging.getLogger("dataprocessor")
+    logger.addHandler(logging.StreamHandler())
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+    elif args.verbose:
+        logger.setLevel(logging.INFO)
+    else:
+        logger.setLevel(logging.WARNING)
+
+    try:
+        main(args)
+    except dp.exception.DataProcessorError as e:
+        if args.debug:
+            print(traceback.format_exc())
+        print("=*= ERROR =*=")
+        print("Message: %s" % e.msg)
+        sys.exit(1)

--- a/lib/dataprocessor/argparsers.py
+++ b/lib/dataprocessor/argparsers.py
@@ -4,6 +4,8 @@ import sys
 
 from . import pipes
 from . import rc
+from .runner import runners
+from .utility import now_str
 
 
 def dpmanip():
@@ -28,6 +30,24 @@ def dpmanip():
             for kwd, attr in val["kwds"]:
                 pipe_psr.add_argument("--" + kwd, **attr)
         pipe_psr.set_defaults(val=val)
+    return parser
+
+
+def dpstart():
+    try:
+        parser = rc.ArgumentParser()
+    except rc.DataProcessorRcError:
+        print("Please create configure file by dpinit")
+        sys.exit(1)
+    parser.add_argument("args", nargs="+", help="command to be executed")
+    parser.add_argument("-n", "--name", nargs="+", default=now_str(),
+                        help="name")
+    parser.add_argument("-p", "--projects", nargs="+", default=[],
+                        help="Project or Tag")
+    parser.add_argument("-r", "--runner", choices=runners, default="sync",
+                        help="Runner")
+    parser.add_argument("--requirements", nargs="+", default=[],
+                        help="Additional requirements")
     return parser
 
 

--- a/lib/dataprocessor/runner.py
+++ b/lib/dataprocessor/runner.py
@@ -55,3 +55,10 @@ def atnow(args, work_dir):
     tmp.write(atnow_template.format(path=work_dir, args=" ".join(args)))
     tmp.flush()
     utility.check_call(['at', 'now', '-f', tmp.name])
+
+
+@runner
+def systemd_user(args, work_dir):
+    """ execute command using systemd-run --user command """
+    utility.check_call(["systemd-run", "--user", "-p",
+                        "WorkingDirectory={}".format(work_dir)] + args)


### PR DESCRIPTION
starterパイプの補助用実行ファイルです。
例えば計算の設定ファイルのような計算に必要なファイルは`dpmanip starter`では

``` command
dpmanip starter ./exec config.yml --requirements ./exec config.yml
```

のように手動で`--requirements`に追加する必要があります。
これを自動的に解決する事が`dpstart`の目的です。

``` command
dpstart ./exec config.yml
```

のように使います。
実行するコマンドから`./exec`と`config.yml`が存在するファイルかどうか判定し、存在すれば自動的にrequirementsに追加します。
また自動的に`exec`タグを追加します。
